### PR TITLE
Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 # Invoke with PYTHON_VERSION=2 (default) or 3
 PYTHON ?= python
-ifeq ($(findstring "Python 2", $(shell $(PYTHON) --version)), "")
+ifeq '$(shell $(PYTHON) sparkl_cli/python_version.py)' '2'
 $(info Your $(PYTHON) is version 2)
 PEP8 := pep8
 DEPS := \

--- a/sparkl_cli/cmd_put.py
+++ b/sparkl_cli/cmd_put.py
@@ -17,8 +17,9 @@ Upload source command implementation.
 """
 from __future__ import print_function
 
-import tempfile
+import os
 import re
+import tempfile
 import requests
 
 

--- a/sparkl_cli/cmd_put.py
+++ b/sparkl_cli/cmd_put.py
@@ -25,6 +25,7 @@ import requests
 
 from sparkl_cli.common import (
     get_current_folder,
+    mktemp,
     resolve,
     sync_request)
 
@@ -70,9 +71,9 @@ def command(args):
 
         if is_url(upload_path):
             response = requests.get(upload_path)
-            _handle, temp_path = tempfile.mkstemp(suffix='.xml')
+            temp_path = mktemp(".xml")
 
-            with open(temp_path, 'w') as content:
+            with open(temp_path, "w") as content:
                 content.write(response.text)
 
             upload_path = temp_path

--- a/sparkl_cli/cmd_put.py
+++ b/sparkl_cli/cmd_put.py
@@ -24,7 +24,7 @@ import requests
 
 from sparkl_cli.common import (
     get_current_folder,
-    mktemp,
+    mktemp_pathname,
     resolve,
     sync_request)
 
@@ -70,7 +70,7 @@ def command(args):
 
         if is_url(upload_path):
             response = requests.get(upload_path)
-            temp_path = mktemp(".xml")
+            temp_path = mktemp_pathname(".xml")
 
             with open(temp_path, "w") as content:
                 content.write(response.text)

--- a/sparkl_cli/cmd_put.py
+++ b/sparkl_cli/cmd_put.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 
 import os
 import re
-import tempfile
 import requests
 
 

--- a/sparkl_cli/cmd_put.py
+++ b/sparkl_cli/cmd_put.py
@@ -18,7 +18,6 @@ Upload source command implementation.
 from __future__ import print_function
 
 import tempfile
-import subprocess
 import re
 import requests
 
@@ -93,4 +92,4 @@ def command(args):
 
     finally:
         if to_delete:
-            subprocess.call(['rm', to_delete])
+            os.remove(to_delete)

--- a/sparkl_cli/cmd_render.py
+++ b/sparkl_cli/cmd_render.py
@@ -68,7 +68,6 @@ def render(src_path, dst_path):
     transform(
         "resources/render.xsl",
         src_path,
-        ["--xincludestyle"],
         dst_path)
 
 

--- a/sparkl_cli/cmd_render.py
+++ b/sparkl_cli/cmd_render.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 
 from shutil import copyfile
 import os
-import subprocess
 from time import sleep
 
 from sparkl_cli.common import get_source, mktemp, transform
@@ -90,6 +89,7 @@ def show_html(args, local=False):
     The temp file is deleted once the source code is returned.
     """
     temp_file = mktemp('.html')
+    print(temp_file)
     try:
         # Get content of tempfile from local file.
         if local:
@@ -100,7 +100,7 @@ def show_html(args, local=False):
         return get_html_content(temp_file, temp_file)
 
     finally:
-        subprocess.check_call(['rm', temp_file])
+        os.remove(temp_file)
 
 
 def save_local_as_html(src, dest):
@@ -111,7 +111,7 @@ def save_local_as_html(src, dest):
     temp_file = mktemp('.html')
     copyfile(src, temp_file)
     render(temp_file, dest)
-    subprocess.check_call(['rm', temp_file])
+    os.remove(temp_file)
 
 
 def download_as_html(args):
@@ -122,7 +122,7 @@ def download_as_html(args):
     temp_file = mktemp('.html')
     get_source(args, temp_file)
     render(temp_file, args.output)
-    subprocess.check_call(['rm', temp_file])
+    os.remove(temp_file)
 
 
 def get_latest_mod(src_file):
@@ -176,7 +176,7 @@ def html_generator(src_file, previous_change, interval):
 
     # Only delete temporary file when generator is terminated.
     finally:
-        subprocess.check_call(['rm', temp_file])
+        os.remove(temp_file)
 
 
 def start_monitoring(src_file, interval):

--- a/sparkl_cli/cmd_render.py
+++ b/sparkl_cli/cmd_render.py
@@ -89,7 +89,6 @@ def show_html(args, local=False):
     The temp file is deleted once the source code is returned.
     """
     temp_file = mktemp('.html')
-    print(temp_file)
     try:
         # Get content of tempfile from local file.
         if local:

--- a/sparkl_cli/cmd_render.py
+++ b/sparkl_cli/cmd_render.py
@@ -21,7 +21,7 @@ from shutil import copyfile
 import os
 from time import sleep
 
-from sparkl_cli.common import get_source, mktemp, transform
+from sparkl_cli.common import get_source, mktemp_pathname, transform
 
 DEFAULT_INTERVAL = 3
 
@@ -88,7 +88,7 @@ def show_html(args, local=False):
 
     The temp file is deleted once the source code is returned.
     """
-    temp_file = mktemp('.html')
+    temp_file = mktemp_pathname('.html')
     try:
         # Get content of tempfile from local file.
         if local:
@@ -107,7 +107,7 @@ def save_local_as_html(src, dest):
     Saves a local file - 'src' - on the file system as 'dest' and
     transforms it into html.
     """
-    temp_file = mktemp('.html')
+    temp_file = mktemp_pathname('.html')
     copyfile(src, temp_file)
     render(temp_file, dest)
     os.remove(temp_file)
@@ -118,7 +118,7 @@ def download_as_html(args):
     Downloads a configuration from a running SPARKL instance.
     The configuration is transformed into html.
     """
-    temp_file = mktemp('.html')
+    temp_file = mktemp_pathname('.html')
     get_source(args, temp_file)
     render(temp_file, args.output)
     os.remove(temp_file)
@@ -152,7 +152,7 @@ def html_generator(src_file, previous_change, interval):
             The rate of frequency the XML source file is checked for changes
     """
     # Create a temporary file for storing the changes.
-    temp_file = mktemp('.html')
+    temp_file = mktemp_pathname('.html')
     try:
         # Render the file on first call of the generator.
         yield get_html_content(src_file, temp_file)

--- a/sparkl_cli/cmd_render.py
+++ b/sparkl_cli/cmd_render.py
@@ -20,10 +20,9 @@ from __future__ import print_function
 from shutil import copyfile
 import os
 import subprocess
-import tempfile
 from time import sleep
 
-from sparkl_cli.common import get_source, transform
+from sparkl_cli.common import get_source, mktemp, transform
 
 DEFAULT_INTERVAL = 3
 
@@ -90,8 +89,7 @@ def show_html(args, local=False):
 
     The temp file is deleted once the source code is returned.
     """
-    _handle, temp_file = tempfile.mkstemp('.html')
-
+    temp_file = mktemp('.html')
     try:
         # Get content of tempfile from local file.
         if local:
@@ -110,7 +108,7 @@ def save_local_as_html(src, dest):
     Saves a local file - 'src' - on the file system as 'dest' and
     transforms it into html.
     """
-    _handle, temp_file = tempfile.mkstemp('.html')
+    temp_file = mktemp('.html')
     copyfile(src, temp_file)
     render(temp_file, dest)
     subprocess.check_call(['rm', temp_file])
@@ -121,7 +119,7 @@ def download_as_html(args):
     Downloads a configuration from a running SPARKL instance.
     The configuration is transformed into html.
     """
-    _handle, temp_file = tempfile.mkstemp('.html')
+    temp_file = mktemp('.html')
     get_source(args, temp_file)
     render(temp_file, args.output)
     subprocess.check_call(['rm', temp_file])
@@ -155,7 +153,7 @@ def html_generator(src_file, previous_change, interval):
             The rate of frequency the XML source file is checked for changes
     """
     # Create a temporary file for storing the changes.
-    _handle, temp_file = tempfile.mkstemp('.html')
+    temp_file = mktemp('.html')
     try:
         # Render the file on first call of the generator.
         yield get_html_content(src_file, temp_file)

--- a/sparkl_cli/cmd_render.py
+++ b/sparkl_cli/cmd_render.py
@@ -65,10 +65,7 @@ def render(src_path, dst_path):
     Applies the render.xsl transform on src_path to
     generate the content of dst_path.
     """
-    transform(
-        "resources/render.xsl",
-        src_path,
-        dst_path)
+    transform("resources/render.xsl", src_path, dst_path)
 
 
 def get_html_content(src_file, temp_file):

--- a/sparkl_cli/cmd_source.py
+++ b/sparkl_cli/cmd_source.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 import os
 
-from sparkl_cli.common import get_source, mktemp
+from sparkl_cli.common import get_source, mktemp_pathname
 
 
 def parse_args(subparser):
@@ -50,7 +50,7 @@ def show_source_as(args):
     """
 
     # Create a temporary file.
-    temp_file = mktemp()
+    temp_file = mktemp_pathname()
     try:
         # Get content of tempfile from local file.
         get_source(args, temp_file)

--- a/sparkl_cli/cmd_source.py
+++ b/sparkl_cli/cmd_source.py
@@ -16,6 +16,8 @@ limitations under the License.
 Get source command implementation.
 """
 from __future__ import print_function
+
+import os
 import tempfile
 
 from sparkl_cli.common import get_source

--- a/sparkl_cli/cmd_source.py
+++ b/sparkl_cli/cmd_source.py
@@ -17,8 +17,6 @@ Get source command implementation.
 """
 from __future__ import print_function
 import tempfile
-import subprocess
-
 
 from sparkl_cli.common import get_source
 
@@ -62,7 +60,7 @@ def show_source_as(args):
 
     # Get rid of tempfile.
     finally:
-        subprocess.call(['rm', temp_file])
+        os.remove(temp_file)
 
 
 def command(args):

--- a/sparkl_cli/cmd_source.py
+++ b/sparkl_cli/cmd_source.py
@@ -18,9 +18,8 @@ Get source command implementation.
 from __future__ import print_function
 
 import os
-import tempfile
 
-from sparkl_cli.common import get_source
+from sparkl_cli.common import get_source, mktemp
 
 
 def parse_args(subparser):
@@ -51,7 +50,7 @@ def show_source_as(args):
     """
 
     # Create a temporary file.
-    (_handle, temp_file) = tempfile.mkstemp()
+    temp_file = mktemp()
     try:
         # Get content of tempfile from local file.
         get_source(args, temp_file)

--- a/sparkl_cli/cmd_tree.py
+++ b/sparkl_cli/cmd_tree.py
@@ -18,9 +18,8 @@ Show text tree command implementation.
 from __future__ import print_function
 
 import os
-import tempfile
 
-from sparkl_cli.common import get_source, transform
+from sparkl_cli.common import get_source, mktemp, transform
 
 
 def parse_args(subparser):
@@ -85,14 +84,13 @@ def command(args):
     """
     if args.file:
         render(args, args.source)
+        return
 
-    else:
-        (_handle, temp_file) = tempfile.mkstemp()
-        try:
-            # Get content of tempfile from local file.
-            get_source(args, temp_file)
-            render(args, temp_file)
+    temp_file = mktemp(".xml")
+    try:
+        get_source(args, temp_file)
+        render(args, temp_file)
 
-        # Remove tempfile.
-        finally:
-            os.remove(temp_file)
+    # Remove tempfile.
+    finally:
+        os.remove(temp_file)

--- a/sparkl_cli/cmd_tree.py
+++ b/sparkl_cli/cmd_tree.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 import os
 
-from sparkl_cli.common import get_source, mktemp, transform
+from sparkl_cli.common import get_source, mktemp_pathname, transform
 
 
 def parse_args(subparser):
@@ -86,7 +86,7 @@ def command(args):
         render(args, args.source)
         return
 
-    temp_file = mktemp(".xml")
+    temp_file = mktemp_pathname(".xml")
     try:
         get_source(args, temp_file)
         render(args, temp_file)

--- a/sparkl_cli/common.py
+++ b/sparkl_cli/common.py
@@ -22,13 +22,14 @@ import platform
 import sys
 import time
 import shutil
-import tempfile
 import json
 import posixpath
 import subprocess
+import tempfile
 from http.cookiejar import LWPCookieJar
 import websocket
 import psutil
+
 
 import requests
 from requests.compat import urljoin, urlsplit, urlunparse
@@ -590,3 +591,14 @@ def xsltproc(xsl, src, dst, **params):
     cmd = ["xsltproc"] + args + [xsl, src]
 
     subprocess.check_call(cmd)
+
+
+def mktemp(suffix=".tmp"):
+    """
+    Creates and closes a temporary file, returning its name only.
+    """
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as named:
+        try:
+            return named.name
+        finally:
+            named.close()

--- a/sparkl_cli/common.py
+++ b/sparkl_cli/common.py
@@ -598,7 +598,4 @@ def mktemp_pathname(suffix=".tmp"):
     Creates and closes a temporary file, returning its name only.
     """
     with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as named:
-        try:
-            return named.name
-        finally:
-            named.close()
+        return named.name

--- a/sparkl_cli/common.py
+++ b/sparkl_cli/common.py
@@ -580,7 +580,7 @@ def xsltproc(xsl, src, dst, **params):
     Invokes the xsltproc wrapper around libxml for
     Darwin and Linux systems.
     """
-    args = ["--xincludestyle"]
+    args = []
     if dst:
         args += ["--output", dst]
 

--- a/sparkl_cli/common.py
+++ b/sparkl_cli/common.py
@@ -593,7 +593,7 @@ def xsltproc(xsl, src, dst, **params):
     subprocess.check_call(cmd)
 
 
-def mktemp(suffix=".tmp"):
+def mktemp_pathname(suffix=".tmp"):
     """
     Creates and closes a temporary file, returning its name only.
     """

--- a/sparkl_cli/python_version.py
+++ b/sparkl_cli/python_version.py
@@ -1,0 +1,20 @@
+"""
+Copyright 2018 SPARKL Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Utility to print major python version on stdout.
+"""
+from __future__ import print_function
+import sys
+print(sys.version_info[0])

--- a/sparkl_cli/resources/render.css
+++ b/sparkl_cli/resources/render.css
@@ -1,3 +1,4 @@
+<style>
 body {
   font-size: small;
   font-family: Arial, sans-serif;
@@ -254,3 +255,4 @@ table.attributes {
 .attr-name {
   font-weight: bold;
 }
+</style>

--- a/sparkl_cli/resources/render.js
+++ b/sparkl_cli/resources/render.js
@@ -1,3 +1,4 @@
+<script><![CDATA[
 /**
  * Copyright 2018 SPARKL Limited
  *
@@ -62,3 +63,4 @@ if (query) {
       }, delay);
   }
 }
+]]></script>

--- a/sparkl_cli/resources/render.xsl
+++ b/sparkl_cli/resources/render.xsl
@@ -422,18 +422,14 @@
     Javascript inline.
   -->
   <xsl:template name="js">
-    <script>
-      <xi:include href="render.js" parse="text"/>
-    </script>
+    <xsl:copy-of select="document('render.js')/script"/>
   </xsl:template>
 
   <!--
     CSS stylesheet inline.
   -->
   <xsl:template name="css">
-    <style>
-      <xi:include href="render.css" parse="text"/>
-    </style>
+    <xsl:copy-of select="document('render.css')/style"/>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/sparkl_cli/resources/render.xsl
+++ b/sparkl_cli/resources/render.xsl
@@ -26,7 +26,7 @@
   xmlns:xi="http://www.w3.org/2001/XInclude"
   exclude-result-prefixes="xsi xi">
 
-  <xsl:output method="html" indent="yes"/>
+  <xsl:output method="html" indent="yes" encoding="UTF-8"/>
 
   <!--
     Generates an HTML document.

--- a/sparkl_cli/resources/tree.xsl
+++ b/sparkl_cli/resources/tree.xsl
@@ -43,24 +43,26 @@
 
   <!--
     See https://www.w3schools.com/charsets/ref_utf_box.asp
+    Note that the Windows console must be set to UTF8 using
+    the chcp 65001 command.
   -->
-  <xsl:variable name="outer-vertical">&#9474;   </xsl:variable>
-  <xsl:variable name="non-terminal">&#9500;&#9472;&#9472; </xsl:variable>
-  <xsl:variable name="non-terminal-mix">&#x251D;&#9472;&#9472; </xsl:variable>
-  <xsl:variable name="terminal">&#9492;&#9472;&#9472; </xsl:variable>
-  <xsl:variable name="terminal-mix">&#9492;&#9472;&#9472; </xsl:variable>
-  <xsl:variable name="mix-prefix">&#956; </xsl:variable>
-  <xsl:variable name="field-prefix">&#159; </xsl:variable>
-  <xsl:variable name="service-prefix">&#177; </xsl:variable>
-  <xsl:variable name="notify-prefix">&gt;&gt; </xsl:variable>
-  <xsl:variable name="solicit-prefix">&gt;&gt; </xsl:variable>
-  <xsl:variable name="response-prefix">&lt;&lt; </xsl:variable>
-  <xsl:variable name="request-prefix">&lt;  </xsl:variable>
-  <xsl:variable name="request-reply-prefix">&gt;  </xsl:variable>
-  <xsl:variable name="consume-prefix">&lt;&lt; </xsl:variable>
-  <xsl:variable name="consume-reply-prefix">&gt;&gt; </xsl:variable>
-  <xsl:variable name="prop-prefix">&#250;  </xsl:variable>
-  <xsl:variable name="content-indicator"> &#244;</xsl:variable>
+  <xsl:variable name="outer-vertical">&#x2502;   </xsl:variable>
+  <xsl:variable name="non-terminal">&#x251C;&#x2500;&#x2500; </xsl:variable>
+  <xsl:variable name="non-terminal-mix">&#x251D;&#x2500;&#x2500; </xsl:variable>
+  <xsl:variable name="terminal">&#x2514;&#x2500;&#x2500; </xsl:variable>
+  <xsl:variable name="terminal-mix">&#x2515;&#x2501;&#x2501; </xsl:variable>
+  <xsl:variable name="mix-prefix">&#x03BC; </xsl:variable>
+  <xsl:variable name="field-prefix">&#x0192; </xsl:variable>
+  <xsl:variable name="service-prefix">&#x2592; </xsl:variable>
+  <xsl:variable name="notify-prefix">&#x21D2;  </xsl:variable>
+  <xsl:variable name="solicit-prefix">&#x21D2;  </xsl:variable>
+  <xsl:variable name="response-prefix">&#x21D0;  </xsl:variable>
+  <xsl:variable name="request-prefix">&#x2190;  </xsl:variable>
+  <xsl:variable name="request-reply-prefix">&#x2192;  </xsl:variable>
+  <xsl:variable name="consume-prefix">&#x21D0;  </xsl:variable>
+  <xsl:variable name="consume-reply-prefix">&#x21D2;  </xsl:variable>
+  <xsl:variable name="prop-prefix">&#x00B7;  </xsl:variable>
+  <xsl:variable name="content-indicator"> &#x00B6;</xsl:variable>
 
   <!--
     Document root.

--- a/sparkl_cli/resources/tree.xsl
+++ b/sparkl_cli/resources/tree.xsl
@@ -48,9 +48,9 @@
   -->
   <xsl:variable name="outer-vertical">&#x2502;   </xsl:variable>
   <xsl:variable name="non-terminal">&#x251C;&#x2500;&#x2500; </xsl:variable>
-  <xsl:variable name="non-terminal-mix">&#x251D;&#x2500;&#x2500; </xsl:variable>
+  <xsl:variable name="non-terminal-mix">&#x255E;&#x2550;&#x2550; </xsl:variable>
   <xsl:variable name="terminal">&#x2514;&#x2500;&#x2500; </xsl:variable>
-  <xsl:variable name="terminal-mix">&#x2515;&#x2501;&#x2501; </xsl:variable>
+  <xsl:variable name="terminal-mix">&#x2558;&#x2550;&#x2550; </xsl:variable>
   <xsl:variable name="mix-prefix">&#x03BC;  </xsl:variable>
   <xsl:variable name="field-prefix">&#x0192;  </xsl:variable>
   <xsl:variable name="service-prefix">&#x2592;  </xsl:variable>

--- a/sparkl_cli/resources/tree.xsl
+++ b/sparkl_cli/resources/tree.xsl
@@ -54,13 +54,13 @@
   <xsl:variable name="mix-prefix">&#x03BC; </xsl:variable>
   <xsl:variable name="field-prefix">&#x0192; </xsl:variable>
   <xsl:variable name="service-prefix">&#x2592; </xsl:variable>
-  <xsl:variable name="notify-prefix">&#x25BA;&#x25BA; </xsl:variable>
-  <xsl:variable name="solicit-prefix">&#x25BA;&#x25BA; </xsl:variable>
-  <xsl:variable name="response-prefix">&#x25C4;&#x25C4; </xsl:variable>
-  <xsl:variable name="request-prefix">&#x25C4;  </xsl:variable>
-  <xsl:variable name="request-reply-prefix">&#x25BA;  </xsl:variable>
-  <xsl:variable name="consume-prefix">&#x25C4;&#x25C4; </xsl:variable>
-  <xsl:variable name="consume-reply-prefix">&#x25BA;&#x25BA; </xsl:variable>
+  <xsl:variable name="notify-prefix">&#x25B8;&#x25B8; </xsl:variable>
+  <xsl:variable name="solicit-prefix">&#x25B8;&#x25B8; </xsl:variable>
+  <xsl:variable name="response-prefix">&#x25C2;&#x25C2; </xsl:variable>
+  <xsl:variable name="request-prefix">&#x25C2;  </xsl:variable>
+  <xsl:variable name="request-reply-prefix">&#x25B8;  </xsl:variable>
+  <xsl:variable name="consume-prefix">&#x25C2;&#x25C2; </xsl:variable>
+  <xsl:variable name="consume-reply-prefix">&#x25B8;&#x25B8; </xsl:variable>
   <xsl:variable name="prop-prefix">&#x00B7;  </xsl:variable>
   <xsl:variable name="content-indicator"> &#x00B6;</xsl:variable>
 

--- a/sparkl_cli/resources/tree.xsl
+++ b/sparkl_cli/resources/tree.xsl
@@ -25,7 +25,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   exclude-result-prefixes="xsi">
 
-  <xsl:output method="text" encoding="ISO-8859-1"/>
+  <xsl:output method="text" encoding="UTF-8"/>
 
   <!--
     Flag to control detail on the line for each entry.
@@ -41,10 +41,15 @@
     response,request,reply,consume,prop
   </xsl:param>
 
-  <xsl:variable name="outer-vertical">&#179;   </xsl:variable>
-  <xsl:variable name="non-terminal">&#195;&#196;&#196; </xsl:variable>
-  <xsl:variable name="terminal">&#192;&#196;&#196; </xsl:variable>
-  <xsl:variable name="mix-prefix">&#230; </xsl:variable>
+  <!--
+    See https://www.w3schools.com/charsets/ref_utf_box.asp
+  -->
+  <xsl:variable name="outer-vertical">&#9474;   </xsl:variable>
+  <xsl:variable name="non-terminal">&#9500;&#9472;&#9472; </xsl:variable>
+  <xsl:variable name="non-terminal-mix">&#x251D;&#9472;&#9472; </xsl:variable>
+  <xsl:variable name="terminal">&#9492;&#9472;&#9472; </xsl:variable>
+  <xsl:variable name="terminal-mix">&#9492;&#9472;&#9472; </xsl:variable>
+  <xsl:variable name="mix-prefix">&#956; </xsl:variable>
   <xsl:variable name="field-prefix">&#159; </xsl:variable>
   <xsl:variable name="service-prefix">&#177; </xsl:variable>
   <xsl:variable name="notify-prefix">&gt;&gt; </xsl:variable>
@@ -124,7 +129,7 @@
           <xsl:when test="following-sibling::*[contains($tags,local-name())]">
             <xsl:choose>
               <xsl:when test="local-name()='mix'">
-                <xsl:value-of select="$non-terminal"/>
+                <xsl:value-of select="$non-terminal-mix"/>
               </xsl:when>
 
               <xsl:otherwise>
@@ -137,7 +142,7 @@
           <xsl:otherwise>
             <xsl:choose>
               <xsl:when test="local-name()='mix'">
-                <xsl:value-of select="$terminal"/>
+                <xsl:value-of select="$terminal-mix"/>
               </xsl:when>
 
               <xsl:otherwise>

--- a/sparkl_cli/resources/tree.xsl
+++ b/sparkl_cli/resources/tree.xsl
@@ -25,7 +25,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   exclude-result-prefixes="xsi">
 
-  <xsl:output method="text"/>
+  <xsl:output method="text" encoding="ISO-8859-1"/>
 
   <!--
     Flag to control detail on the line for each entry.
@@ -40,6 +40,22 @@
     folder,mix,service,field,notify,solicit,
     response,request,reply,consume,prop
   </xsl:param>
+
+  <xsl:variable name="outer-vertical">&#179;   </xsl:variable>
+  <xsl:variable name="non-terminal">&#195;&#196;&#196; </xsl:variable>
+  <xsl:variable name="terminal">&#192;&#196;&#196; </xsl:variable>
+  <xsl:variable name="mix-prefix">&#230; </xsl:variable>
+  <xsl:variable name="field-prefix">&#159; </xsl:variable>
+  <xsl:variable name="service-prefix">&#177; </xsl:variable>
+  <xsl:variable name="notify-prefix">&gt;&gt; </xsl:variable>
+  <xsl:variable name="solicit-prefix">&gt;&gt; </xsl:variable>
+  <xsl:variable name="response-prefix">&lt;&lt; </xsl:variable>
+  <xsl:variable name="request-prefix">&lt;  </xsl:variable>
+  <xsl:variable name="request-reply-prefix">&gt;  </xsl:variable>
+  <xsl:variable name="consume-prefix">&lt;&lt; </xsl:variable>
+  <xsl:variable name="consume-reply-prefix">&gt;&gt; </xsl:variable>
+  <xsl:variable name="prop-prefix">&#250;  </xsl:variable>
+  <xsl:variable name="content-indicator"> &#244;</xsl:variable>
 
   <!--
     Document root.
@@ -91,7 +107,7 @@
       <xsl:when test="position()!=last()">
         <xsl:choose>
           <xsl:when test="following-sibling::*[contains($tags,local-name())]">
-            <xsl:text>│   </xsl:text>
+            <xsl:value-of select="$outer-vertical"/>
           </xsl:when>
 
           <xsl:otherwise>
@@ -108,11 +124,11 @@
           <xsl:when test="following-sibling::*[contains($tags,local-name())]">
             <xsl:choose>
               <xsl:when test="local-name()='mix'">
-                <xsl:text>╞══ </xsl:text>
+                <xsl:value-of select="$non-terminal"/>
               </xsl:when>
 
               <xsl:otherwise>
-                <xsl:text>├── </xsl:text>
+                <xsl:value-of select="$non-terminal"/>
               </xsl:otherwise>
             </xsl:choose>
 
@@ -121,11 +137,11 @@
           <xsl:otherwise>
             <xsl:choose>
               <xsl:when test="local-name()='mix'">
-                <xsl:text>╘══ </xsl:text>
+                <xsl:value-of select="$terminal"/>
               </xsl:when>
 
               <xsl:otherwise>
-                <xsl:text>└── </xsl:text>
+                <xsl:value-of select="$terminal"/>
               </xsl:otherwise>
             </xsl:choose>
 
@@ -145,14 +161,14 @@
   </xsl:template>
 
   <xsl:template match="mix" mode="leaf">
-    <xsl:text>µ </xsl:text>
+    <xsl:value-of select="$mix-prefix"/>
     <xsl:value-of select="@name"/>
 
     <xsl:call-template name="grants"/>
   </xsl:template>
 
   <xsl:template match="field" mode="leaf">
-    <xsl:text>ƒ </xsl:text>
+    <xsl:value-of select="$field-prefix"/>
     <xsl:value-of select="@name"/>
 
     <xsl:if test="$detail and @type">
@@ -162,7 +178,7 @@
   </xsl:template>
 
   <xsl:template match="service" mode="leaf">
-    <xsl:text>▒ </xsl:text>
+    <xsl:value-of select="$service-prefix"/>
     <xsl:value-of select="@name"/>
 
     <xsl:if test="$detail">
@@ -174,7 +190,7 @@
   </xsl:template>
 
   <xsl:template match="notify" mode="leaf">
-    <xsl:text>&gt;&gt; </xsl:text>
+    <xsl:value-of select="$notify-prefix"/>
     <xsl:value-of select="@name"/>
 
     <xsl:call-template name="service_ref"/>
@@ -182,7 +198,7 @@
   </xsl:template>
 
   <xsl:template match="solicit" mode="leaf">
-    <xsl:text>&gt;&gt; </xsl:text>
+    <xsl:value-of select="$solicit-prefix"/>
     <xsl:value-of select="@name"/>
 
     <xsl:call-template name="service_ref"/>
@@ -190,7 +206,7 @@
   </xsl:template>
 
   <xsl:template match="request" mode="leaf">
-    <xsl:text>&lt;  </xsl:text>
+    <xsl:value-of select="$request-prefix"/>
     <xsl:value-of select="@name"/>
 
     <xsl:call-template name="service_ref"/>
@@ -198,7 +214,7 @@
   </xsl:template>
 
   <xsl:template match="consume" mode="leaf">
-    <xsl:text>&lt;&lt; </xsl:text>
+    <xsl:value-of select="$consume-prefix"/>
     <xsl:value-of select="@name"/>
 
     <xsl:call-template name="service_ref"/>
@@ -206,28 +222,28 @@
   </xsl:template>
 
   <xsl:template match="response" mode="leaf">
-    <xsl:text>&lt;&lt; </xsl:text>
+    <xsl:value-of select="$response-prefix"/>
     <xsl:value-of select="@name"/>
 
     <xsl:call-template name="field_refs"/>
   </xsl:template>
 
   <xsl:template match="request/reply" mode="leaf">
-    <xsl:text>&gt; </xsl:text>
+    <xsl:value-of select="$request-reply-prefix"/>
     <xsl:value-of select="@name"/>
 
     <xsl:call-template name="field_refs"/>
   </xsl:template>
 
   <xsl:template match="consume/reply" mode="leaf">
-    <xsl:text>&gt;&gt; </xsl:text>
+    <xsl:value-of select="$consume-reply-prefix"/>
     <xsl:value-of select="@name"/>
 
     <xsl:call-template name="field_refs"/>
   </xsl:template>
 
   <xsl:template match="prop" mode="leaf">
-    <xsl:text>○ </xsl:text>
+    <xsl:value-of select="$prop-prefix"/>
     <xsl:value-of select="@name"/>
 
     <xsl:call-template name="prop-detail"/>
@@ -270,7 +286,7 @@
       </xsl:for-each>
 
       <xsl:if test="text()">
-        <xsl:text> ¶</xsl:text>
+        <xsl:value-of select="$content-indicator"/>
       </xsl:if>
     </xsl:if>
   </xsl:template>

--- a/sparkl_cli/resources/tree.xsl
+++ b/sparkl_cli/resources/tree.xsl
@@ -51,17 +51,17 @@
   <xsl:variable name="non-terminal-mix">&#x251D;&#x2500;&#x2500; </xsl:variable>
   <xsl:variable name="terminal">&#x2514;&#x2500;&#x2500; </xsl:variable>
   <xsl:variable name="terminal-mix">&#x2515;&#x2501;&#x2501; </xsl:variable>
-  <xsl:variable name="mix-prefix">&#x03BC; </xsl:variable>
-  <xsl:variable name="field-prefix">&#x0192; </xsl:variable>
-  <xsl:variable name="service-prefix">&#x2592; </xsl:variable>
-  <xsl:variable name="notify-prefix">&#x25B8;&#x25B8; </xsl:variable>
-  <xsl:variable name="solicit-prefix">&#x25B8;&#x25B8; </xsl:variable>
-  <xsl:variable name="response-prefix">&#x25C2;&#x25C2; </xsl:variable>
-  <xsl:variable name="request-prefix">&#x25C2;  </xsl:variable>
-  <xsl:variable name="request-reply-prefix">&#x25B8;  </xsl:variable>
-  <xsl:variable name="consume-prefix">&#x25C2;&#x25C2; </xsl:variable>
-  <xsl:variable name="consume-reply-prefix">&#x25B8;&#x25B8; </xsl:variable>
-  <xsl:variable name="prop-prefix">&#x00B7;  </xsl:variable>
+  <xsl:variable name="mix-prefix">&#x03BC;  </xsl:variable>
+  <xsl:variable name="field-prefix">&#x0192;  </xsl:variable>
+  <xsl:variable name="service-prefix">&#x2592;  </xsl:variable>
+  <xsl:variable name="notify-prefix">&gt;&gt; </xsl:variable>
+  <xsl:variable name="solicit-prefix">&gt;&gt; </xsl:variable>
+  <xsl:variable name="response-prefix">&lt;&lt; </xsl:variable>
+  <xsl:variable name="request-prefix">&lt;  </xsl:variable>
+  <xsl:variable name="request-reply-prefix">&gt;  </xsl:variable>
+  <xsl:variable name="consume-prefix">&lt;&lt; </xsl:variable>
+  <xsl:variable name="consume-reply-prefix">&gt;&gt; </xsl:variable>
+  <xsl:variable name="prop-prefix">&#x25CB;  </xsl:variable>
   <xsl:variable name="content-indicator"> &#x00B6;</xsl:variable>
 
   <!--

--- a/sparkl_cli/resources/tree.xsl
+++ b/sparkl_cli/resources/tree.xsl
@@ -54,13 +54,13 @@
   <xsl:variable name="mix-prefix">&#x03BC; </xsl:variable>
   <xsl:variable name="field-prefix">&#x0192; </xsl:variable>
   <xsl:variable name="service-prefix">&#x2592; </xsl:variable>
-  <xsl:variable name="notify-prefix">&#x21D2;  </xsl:variable>
-  <xsl:variable name="solicit-prefix">&#x21D2;  </xsl:variable>
-  <xsl:variable name="response-prefix">&#x21D0;  </xsl:variable>
-  <xsl:variable name="request-prefix">&#x2190;  </xsl:variable>
-  <xsl:variable name="request-reply-prefix">&#x2192;  </xsl:variable>
-  <xsl:variable name="consume-prefix">&#x21D0;  </xsl:variable>
-  <xsl:variable name="consume-reply-prefix">&#x21D2;  </xsl:variable>
+  <xsl:variable name="notify-prefix">&#x25BA;&#x25BA; </xsl:variable>
+  <xsl:variable name="solicit-prefix">&#x25BA;&#x25BA; </xsl:variable>
+  <xsl:variable name="response-prefix">&#x25C4;&#x25C4; </xsl:variable>
+  <xsl:variable name="request-prefix">&#x25C4;  </xsl:variable>
+  <xsl:variable name="request-reply-prefix">&#x25BA;  </xsl:variable>
+  <xsl:variable name="consume-prefix">&#x25C4;&#x25C4; </xsl:variable>
+  <xsl:variable name="consume-reply-prefix">&#x25BA;&#x25BA; </xsl:variable>
   <xsl:variable name="prop-prefix">&#x00B7;  </xsl:variable>
   <xsl:variable name="content-indicator"> &#x00B6;</xsl:variable>
 

--- a/sparkl_cli/test/test_put_source_rm.py
+++ b/sparkl_cli/test/test_put_source_rm.py
@@ -29,7 +29,7 @@ import socketserver
 import requests
 
 from sparkl_cli.main import sparkl
-from sparkl_cli.common import mktemp
+from sparkl_cli.common import mktemp_pathname
 
 TEST_SSE = os.environ.get("TEST_SSE")
 TEST_USER = os.environ.get("TEST_USER")
@@ -149,7 +149,7 @@ class Tests():
     def test_render_local_monitor(self):
 
         # Create temporary file and copy Primes into it
-        temp_path = mktemp(".xml")
+        temp_path = mktemp_pathname(".xml")
         copyfile(PRIMES_FILE_PATH, temp_path)
 
         # Start monitoring in a separate process

--- a/sparkl_cli/test/test_put_source_rm.py
+++ b/sparkl_cli/test/test_put_source_rm.py
@@ -21,7 +21,6 @@ import os
 import types
 import glob
 import xml.dom.minidom
-import tempfile
 from shutil import copyfile
 from multiprocessing import Process
 from time import sleep
@@ -30,6 +29,7 @@ import socketserver
 import requests
 
 from sparkl_cli.main import sparkl
+from sparkl_cli.common import mktemp
 
 TEST_SSE = os.environ.get("TEST_SSE")
 TEST_USER = os.environ.get("TEST_USER")
@@ -149,7 +149,7 @@ class Tests():
     def test_render_local_monitor(self):
 
         # Create temporary file and copy Primes into it
-        _handle, temp_path = tempfile.mkstemp('.xml')
+        temp_path = mktemp(".xml")
         copyfile(PRIMES_FILE_PATH, temp_path)
 
         # Start monitoring in a separate process


### PR DESCRIPTION
Various fixes to allow the cli to work under windoze.

For rendering `sparkl tree`, it is important to do `chcp 65001` in the Windoze console, to enable UTF-8 support.